### PR TITLE
Change the underlying container to distroless

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to `grype`
+# Contributing to `kai`
 
 If you are looking to contribute to this project and want to open a Github pull request ("PR"), there are a few guidelines of what we are looking for in patches. Make sure you go through this document and ensure that your code proposal is aligned.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
 FROM gcr.io/distroless/static:nonroot
 
-COPY kai /
+COPY kai /usr/bin
 
 USER nonroot:nobody
 
-ENTRYPOINT ["/kai"]
-CMD ["--config", "/.kai.yaml"]
+ENTRYPOINT ["kai"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,8 @@
-FROM scratch
-ENTRYPOINT ["/kai"]
+FROM gcr.io/distroless/static:nonroot
+
 COPY kai /
+
+ENTRYPOINT ["/kai"]
+
+CMD ["--config", "/.kai.yaml"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM gcr.io/distroless/static:nonroot
 
 COPY kai /
 
+USER nonroot:nobody
+
 ENTRYPOINT ["/kai"]
-
 CMD ["--config", "/.kai.yaml"]
-


### PR DESCRIPTION
Right now kai will fail in-cluster whenever any kind of TLS is required. Golang uses the environments SSL certs and none of those are present in the `scratch` container. I'm just changing the underlying container to distroless which comes with ca certs bundled. Also putting the config flag in a `CMD` so it'll find the config that the chart mounts in.

Signed-off-by: James Petersen <jpetersenames@gmail.com>