### PR TITLE
Chunk the namespace and pod fetching

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,7 +19,7 @@ import (
 var rootCmd = &cobra.Command{
 	Use:   "kai",
 	Short: "KAI tells Anchore which images are in use in your Kubernetes Cluster",
-	Long: `KAI (Kubernetes Automated Inventory) can poll 
+	Long: `KAI (Kubernetes Automated Inventory) can poll
     Kubernetes Cluster API(s) to tell Anchore which Images are currently in-use`,
 	Args: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -92,7 +92,7 @@ func init() {
 		if err != nil {
 			return []string{"failed to build kubeconfig from app config"}, cobra.ShellCompDirectiveError
 		}
-		namespaces, err := kai.GetAllNamespaces(kubeConfig, appConfig.KubernetesRequestTimeoutSeconds)
+		namespaces, err := kai.GetAllNamespaces(kubeConfig, appConfig.Kubernetes)
 		if err != nil {
 			return []string{"completion failed"}, cobra.ShellCompDirectiveError
 		}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,20 +38,25 @@ type CliOnlyOptions struct {
 
 // All Application configurations
 type Application struct {
-	ConfigPath                      string
-	PresenterOpt                    presenter.Option
-	Output                          string  `mapstructure:"output"`
-	Quiet                           bool    `mapstructure:"quiet"`
-	Log                             Logging `mapstructure:"log"`
-	CliOptions                      CliOnlyOptions
-	Dev                             Development `mapstructure:"dev"`
-	KubeConfig                      KubeConf    `mapstructure:"kubeconfig"`
-	KubernetesRequestTimeoutSeconds int64       `mapstructure:"kubernetes-request-timeout-seconds"`
-	Namespaces                      []string    `mapstructure:"namespaces"`
-	RunMode                         mode.Mode
-	Mode                            string      `mapstructure:"mode"`
-	PollingIntervalSeconds          int         `mapstructure:"polling-interval-seconds"`
-	AnchoreDetails                  AnchoreInfo `mapstructure:"anchore"`
+	ConfigPath             string
+	PresenterOpt           presenter.Option
+	Output                 string  `mapstructure:"output"`
+	Quiet                  bool    `mapstructure:"quiet"`
+	Log                    Logging `mapstructure:"log"`
+	CliOptions             CliOnlyOptions
+	Dev                    Development   `mapstructure:"dev"`
+	KubeConfig             KubeConf      `mapstructure:"kubeconfig"`
+	Kubernetes             KubernetesAPI `mapstructure:"kubernetes"`
+	Namespaces             []string      `mapstructure:"namespaces"`
+	RunMode                mode.Mode
+	Mode                   string      `mapstructure:"mode"`
+	PollingIntervalSeconds int         `mapstructure:"polling-interval-seconds"`
+	AnchoreDetails         AnchoreInfo `mapstructure:"anchore"`
+}
+
+type KubernetesAPI struct {
+	RequestTimeoutSeconds int64 `mapstructure:"request-timeout-seconds"`
+	ListLimit             int64 `mapstructure:"list-limit"`
 }
 
 // Information for posting in-use image details to Anchore (or any URL for that matter)
@@ -98,7 +103,8 @@ func setNonCliDefaultValues(v *viper.Viper) {
 	v.SetDefault("kubeconfig.anchore.account", "admin")
 	v.SetDefault("anchore.http.insecure", false)
 	v.SetDefault("anchore.http.timeoutSeconds", 10)
-	v.SetDefault("kubernetes-request-timeout-seconds", 60)
+	v.SetDefault("kubernetes.request-timeout-seconds", 60)
+	v.SetDefault("kubernetes.batch-limit", 100)
 }
 
 // Load the Application Configuration from the Viper specifications


### PR DESCRIPTION
Add the capability to chunk the namespace and pod lists when retrieving from kubernetes. The new functionality will fetch N namespaces and return them through a channel where the pods in each namespace can be retrieved while the next N namespaces are returned. Makes use of the Limit and Continue parameters for ListOptions in the k8s API.

Ref: https://pkg.go.dev/k8s.io/apimachinery/pkg/apis/meta/v1#ListOptions