### PR TITLE
Implement a worker pool

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,6 +57,7 @@ type Application struct {
 type KubernetesAPI struct {
 	RequestTimeoutSeconds int64 `mapstructure:"request-timeout-seconds"`
 	RequestBatchSize      int64 `mapstructure:"request-batch-size"`
+	WorkerPoolSize        int64 `mapstructure:"worker-pool-size"`
 }
 
 // Information for posting in-use image details to Anchore (or any URL for that matter)
@@ -105,6 +106,7 @@ func setNonCliDefaultValues(v *viper.Viper) {
 	v.SetDefault("anchore.http.timeoutSeconds", 10)
 	v.SetDefault("kubernetes.request-timeout-seconds", 60)
 	v.SetDefault("kubernetes.request-batch-size", 100)
+	v.SetDefault("kubernetes.worker-pool-size", 100)
 }
 
 // Load the Application Configuration from the Viper specifications

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -57,7 +57,7 @@ type Application struct {
 type KubernetesAPI struct {
 	RequestTimeoutSeconds int64 `mapstructure:"request-timeout-seconds"`
 	RequestBatchSize      int64 `mapstructure:"request-batch-size"`
-	WorkerPoolSize        int64 `mapstructure:"worker-pool-size"`
+	WorkerPoolSize        int   `mapstructure:"worker-pool-size"`
 }
 
 // Information for posting in-use image details to Anchore (or any URL for that matter)

--- a/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
@@ -26,8 +26,7 @@ kubeconfig:
 kubernetes:
   requesttimeoutseconds: 60
   requestbatchsize: 100
-namespaces:
-- all
+namespaces: []
 runmode: 0
 mode: adhoc
 pollingintervalseconds: 300

--- a/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
@@ -26,6 +26,7 @@ kubeconfig:
 kubernetes:
   requesttimeoutseconds: 60
   requestbatchsize: 100
+  workerpoolsize: 100
 namespaces: []
 runmode: 0
 mode: adhoc

--- a/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
@@ -26,6 +26,7 @@ kubeconfig:
 kubernetes:
   requesttimeoutseconds: 0
   requestbatchsize: 0
+  workerpoolsize: 0
 namespaces: []
 runmode: 0
 mode: ""

--- a/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
@@ -26,8 +26,7 @@ kubeconfig:
 kubernetes:
   requesttimeoutseconds: 60
   requestbatchsize: 100
-namespaces:
-- all
+namespaces: []
 runmode: 0
 mode: adhoc
 pollingintervalseconds: 300

--- a/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
@@ -26,6 +26,7 @@ kubeconfig:
 kubernetes:
   requesttimeoutseconds: 60
   requestbatchsize: 100
+  workerpoolsize: 100
 namespaces: []
 runmode: 0
 mode: adhoc

--- a/kai.yaml
+++ b/kai.yaml
@@ -28,9 +28,8 @@ kubeconfig:
     private-key:
     token:
 
-# Which namespaces to search (can just be a single element "all" or it can be multiple)
-namespaces:
-  - all
+# Which namespaces to search. Will search all namespaces if left as an empty array
+namespaces: []
 
 # Kubernetes API configuration parameters (should not need tuning)
 kubernetes:

--- a/kai.yaml
+++ b/kai.yaml
@@ -39,6 +39,9 @@ kubernetes:
   # Sets the number of objects to iteratively return when listing resources
   request-batch-size: 100
 
+  # Worker pool size for collecting pods from namespaces. Adjust this if the api-server gets overwhelmed
+  worker-pool-size: 100
+
 # Can be one of adhoc, periodic (defaults to adhoc)
 mode: adhoc
 

--- a/kai/lib.go
+++ b/kai/lib.go
@@ -89,11 +89,10 @@ func GetInventoryReport(cfg *config.Application) (inventory.Report, error) {
 	close(queue)
 
 	// get pods from namespaces using a worker pool pattern
-	numWorkers := 100
-	for i := 0; i < numWorkers; i++ {
+	for i := int64(0); i < cfg.Kubernetes.WorkerPoolSize; i++ {
 		go func() {
-			for item := range queue {
-				fetchPodsInNamespace(kubeconfig, cfg.Kubernetes, item, ch)
+			for namespace := range queue {
+				fetchPodsInNamespace(kubeconfig, cfg.Kubernetes, namespace, ch)
 			}
 		}()
 	}

--- a/kai/lib.go
+++ b/kai/lib.go
@@ -134,15 +134,7 @@ func GetInventoryReport(cfg *config.Application) (inventory.Report, error) {
 // either return the namespaces detailed in the configuration OR if "all" is specified then it will
 // call fetchAllNamespaces to return every namespace in the cluster.
 func fetchNamespaces(kubeconfig *rest.Config, cfg *config.Application, nsCh chan k8sNamespace) {
-	getAll := false
-	for _, ns := range cfg.Namespaces {
-		if ns == "all" {
-			getAll = true
-			break
-		}
-	}
-
-	if len(cfg.Namespaces) == 0 || getAll {
+	if len(cfg.Namespaces) == 0 {
 		fetchAllNamespaces(kubeconfig, cfg.Kubernetes, nsCh)
 	} else {
 		for _, ns := range cfg.Namespaces {

--- a/kai/lib.go
+++ b/kai/lib.go
@@ -92,7 +92,7 @@ func GetInventoryReport(cfg *config.Application) (inventory.Report, error) {
 	close(queue)
 
 	// get pods from namespaces using a worker pool pattern
-	for i := int64(0); i < cfg.Kubernetes.WorkerPoolSize; i++ {
+	for i := 0; i < cfg.Kubernetes.WorkerPoolSize; i++ {
 		go func() {
 			// each worker needs its own clientset
 			clientset, err := client.GetClientSet(kubeconfig)


### PR DESCRIPTION
Implement a worker pool for the pod collection. That way the api server does not get overwhelmed when there are 1000's of namespaces.

I had a whole worker pool package implementation based off https://github.com/found-it/worker-pools but it started to get messy so I decided to keep it simple with the anonymous function. Happy to hear some feedback

Other minor change: kai will collect all namespaces if the `namespaces` config is an empty list. That way we avoid a conflict if the end user has a namespace named "all"