### PR TITLE
Kai default configuration has a typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,7 @@ coverage.txt
 *.out
 
 # vim swap files
-*.swp
+*.sw?
 
 # Kubeconfigs contain sensitive information and are specific to someone's environment
 # Ignore it in case anyone puts it in the dir

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ coverage.txt
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# vim swap files
+*.swp
+
 # Kubeconfigs contain sensitive information and are specific to someone's environment
 # Ignore it in case anyone puts it in the dir
 kubeconfig

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,7 +46,7 @@ var rootCmd = &cobra.Command{
 		case mode.PeriodicPolling:
 			kai.PeriodicallyGetInventoryReport(appConfig)
 		default:
-			imagesResult, err := kai.GetInventoryReport(appConfig)
+			report, err := kai.GetInventoryReport(appConfig)
 			if appConfig.Dev.ProfileCPU {
 				pprof.StopCPUProfile()
 			}
@@ -54,7 +54,7 @@ var rootCmd = &cobra.Command{
 				log.Errorf("Failed to get Image Results: %+v", err)
 				os.Exit(1)
 			} else {
-				err := kai.HandleReport(imagesResult, appConfig)
+				err := kai.HandleReport(report, appConfig)
 				if err != nil {
 					log.Errorf("Failed to handle Image Results: %+v", err)
 					os.Exit(1)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,19 +83,6 @@ func init() {
 		os.Exit(1)
 	}
 
-	opt = "namespaces"
-	rootCmd.Flags().StringSliceP(opt, "n", []string{"all"}, "(optional) namespaces to search")
-	err := rootCmd.RegisterFlagCompletionFunc(opt, func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		return []string{"all"}, cobra.ShellCompDirectiveDefault
-	})
-	if err != nil {
-		fmt.Printf("unable to register flag completion script for \"namespace\": %+v", err)
-	}
-	if err := viper.BindPFlag(opt, rootCmd.Flags().Lookup(opt)); err != nil {
-		fmt.Printf("unable to bind flag '%s': %+v", opt, err)
-		os.Exit(1)
-	}
-
 	opt = "mode"
 	rootCmd.Flags().StringP(opt, "m", mode.AdHoc.String(), fmt.Sprintf("execution mode, options=%v", mode.Modes))
 	if err := viper.BindPFlag(opt, rootCmd.Flags().Lookup(opt)); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -109,7 +109,7 @@ func setNonCliDefaultValues(v *viper.Viper) {
 	v.SetDefault("anchore.account", "admin")
 	v.SetDefault("kubeconfig.anchore.account", "admin")
 	v.SetDefault("anchore.http.insecure", false)
-	v.SetDefault("anchore.http.timeoutSeconds", 10)
+	v.SetDefault("anchore.http.timeout-seconds", 10)
 	v.SetDefault("kubernetes.request-timeout-seconds", 60)
 	v.SetDefault("kubernetes.request-batch-size", 100)
 	v.SetDefault("kubernetes.worker-pool-size", 100)

--- a/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
@@ -38,4 +38,4 @@ anchoredetails:
   account: admin
   http:
     insecure: false
-    timeoutseconds: 0
+    timeoutseconds: 5

--- a/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
@@ -41,4 +41,4 @@ anchoredetails:
   account: admin
   http:
     insecure: false
-    timeoutseconds: 5
+    timeoutseconds: 10

--- a/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
@@ -38,4 +38,4 @@ anchoredetails:
   account: admin
   http:
     insecure: false
-    timeoutseconds: 0
+    timeoutseconds: 5

--- a/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
@@ -41,4 +41,4 @@ anchoredetails:
   account: admin
   http:
     insecure: false
-    timeoutseconds: 5
+    timeoutseconds: 10

--- a/kai.yaml
+++ b/kai.yaml
@@ -70,4 +70,4 @@ anchore:
   password: $KAI_ANCHORE_PASSWORD
 #  http:
 #    insecure: true
-#    timeout-seconds: 5
+#    timeout-seconds: 10

--- a/kai.yaml
+++ b/kai.yaml
@@ -54,4 +54,4 @@ anchore:
   password: $KAI_ANCHORE_PASSWORD
 #  http:
 #    insecure: true
-#    timeoutSeconds: 5
+#    timeout-seconds: 5

--- a/kai/inventory/reportitem.go
+++ b/kai/inventory/reportitem.go
@@ -34,7 +34,6 @@ func New(namespace string) *ReportItem {
 
 // NewReportItem parses a list of pods into a ReportItem full of unique images
 func NewReportItem(pods []v1.Pod, namespace string) ReportItem {
-
 	reportItem := ReportItem{
 		Namespace: namespace,
 		Images:    []ReportImage{},

--- a/kai/lib.go
+++ b/kai/lib.go
@@ -164,9 +164,8 @@ type excludeCheck func(namespace string) bool
 
 // excludeRegex compiles a regex to use for namespace matching
 func excludeRegex(check string) excludeCheck {
-	re := regexp.MustCompile(check)
 	return func(namespace string) bool {
-		return re.MatchString(namespace)
+		return regexp.MustCompile(check).MatchString(namespace)
 	}
 }
 
@@ -187,11 +186,9 @@ var validNamespaceRegex *regexp.Regexp = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]
 // name. If the namespace string in the exclude list is a valid dns name then
 // it will add it to a map for direct lookup when the checks are run.
 func buildExclusionChecklist(exclusions []string) []excludeCheck {
-
 	var excludeChecks []excludeCheck
 
 	if len(exclusions) > 0 {
-
 		excludeMap := make(map[string]struct{})
 
 		for _, ex := range exclusions {

--- a/test/integration/get_images_test.go
+++ b/test/integration/get_images_test.go
@@ -23,14 +23,6 @@ func TestGetImageResults(t *testing.T) {
 		t.Errorf("Failed to include Server Version Metadata in report")
 	}
 
-	if report.ClusterName == "" {
-		t.Errorf("Failed to include ClusterName in report")
-	}
-
-	if report.InventoryType == "" {
-		t.Errorf("Failed to include InventoryType in report")
-	}
-
 	if report.Timestamp == "" {
 		t.Errorf("Failed to include Timestamp in report")
 	}


### PR DESCRIPTION
kai.yaml contained a typo in regards to which keyword
golang was looking for to set the http.timeout-seconds mapstructure.
The following changes updates the config file and the required golden
test file to reflect this change.

Signed-off-by: Toure Dunnon <toure.dunnon@anchore.com>

fixes: https://github.com/anchore/kai/issues/33