### PR TITLE
Improve the ReportImage parsing

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,7 @@ type Application struct {
 	Namespaces             []string      `mapstructure:"namespaces"`
 	RunMode                mode.Mode
 	Mode                   string      `mapstructure:"mode"`
+	IgnoreNotRunning       bool        `mapstructure:"ignore-not-running"`
 	PollingIntervalSeconds int         `mapstructure:"polling-interval-seconds"`
 	AnchoreDetails         AnchoreInfo `mapstructure:"anchore"`
 }
@@ -107,6 +108,7 @@ func setNonCliDefaultValues(v *viper.Viper) {
 	v.SetDefault("kubernetes.request-timeout-seconds", 60)
 	v.SetDefault("kubernetes.request-batch-size", 100)
 	v.SetDefault("kubernetes.worker-pool-size", 100)
+	v.SetDefault("ignore-not-running", true)
 }
 
 // Load the Application Configuration from the Viper specifications

--- a/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
@@ -30,6 +30,7 @@ kubernetes:
 namespaces: []
 runmode: 0
 mode: adhoc
+ignorenotrunning: true
 pollingintervalseconds: 300
 anchoredetails:
   url: ""

--- a/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
@@ -30,6 +30,7 @@ kubernetes:
 namespaces: []
 runmode: 0
 mode: ""
+ignorenotrunning: false
 pollingintervalseconds: 0
 anchoredetails:
   url: ""

--- a/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
@@ -30,6 +30,7 @@ kubernetes:
 namespaces: []
 runmode: 0
 mode: adhoc
+ignorenotrunning: true
 pollingintervalseconds: 300
 anchoredetails:
   url: ""

--- a/kai.yaml
+++ b/kai.yaml
@@ -45,6 +45,9 @@ kubernetes:
 # Can be one of adhoc, periodic (defaults to adhoc)
 mode: adhoc
 
+# Ignore images out of pods that are not in a Running state
+ignore-not-running: true
+
 # Only respected if mode is periodic
 polling-interval-seconds: 300
 

--- a/kai/inventory/reportitem.go
+++ b/kai/inventory/reportitem.go
@@ -36,7 +36,7 @@ func NewReportItem(pods []v1.Pod, namespace string, ignoreNotRunning bool) Repor
 		err := reportItem.extractUniqueImages(pod)
 		if err != nil {
 			// Log the failure and continue processing pods
-			log.Errorf("Issue processing images in %s/%s", pod.GetNamespace(), pod.GetName())
+			log.Errorf("Issue processing images in %s/%s - %s", pod.GetNamespace(), pod.GetName(), err)
 		}
 	}
 
@@ -120,7 +120,7 @@ type image struct {
 var digestRegex *regexp.Regexp = regexp.MustCompile(`@(sha[[:digit:]]{3}:[[:alnum:]]{32,})`)
 var tagRegex *regexp.Regexp = regexp.MustCompile(`:[\w][\w.-]{0,127}$`)
 
-// extractImageDetails extracts the image, tag, and digest of an image out of the fields
+// extractImageDetails extracts the repo, tag, and digest of an image out of the fields
 // grabbed from the pod.
 func (img *image) extractImageDetails(s string) error {
 

--- a/kai/inventory/reportitem.go
+++ b/kai/inventory/reportitem.go
@@ -2,34 +2,24 @@ package inventory
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
+
+	"github.com/anchore/kai/internal/log"
 
 	v1 "k8s.io/api/core/v1"
 )
 
-// Represents a ReportItem Images list result
+// ReportItem represents a ReportItem Images list result
 type ReportItem struct {
 	Namespace string        `json:"namespace,omitempty"`
 	Images    []ReportImage `json:"images"`
 }
 
+// ReportImage represents a unique image in a cluster
 type ReportImage struct {
 	Tag        string `json:"tag,omitempty"`
 	RepoDigest string `json:"repoDigest,omitempty"`
-}
-
-func NewFromPod(pod v1.Pod) *ReportItem {
-	return &ReportItem{
-		Namespace: pod.Namespace,
-		Images:    getUniqueImagesFromPodStatus(pod),
-	}
-}
-
-func New(namespace string) *ReportItem {
-	return &ReportItem{
-		Namespace: namespace,
-		Images:    []ReportImage{},
-	}
 }
 
 // NewReportItem parses a list of pods into a ReportItem full of unique images
@@ -45,7 +35,7 @@ func NewReportItem(pods []v1.Pod, namespace string) ReportItem {
 		if namespace == "" || len(pod.Status.ContainerStatuses) == 0 {
 			continue
 		}
-		reportItem.AddImages(pod)
+		reportItem.extractUniqueImages(pod)
 	}
 
 	return reportItem
@@ -57,21 +47,22 @@ func (r *ReportItem) String() string {
 }
 
 // Adds an ReportImage to the ReportItem struct (if it doesn't exist there already)
-func (r *ReportItem) AddImages(pod v1.Pod) {
+func (r *ReportItem) extractUniqueImages(pod v1.Pod) {
 
 	if len(r.Images) == 0 {
-		r.Images = getUniqueImagesFromPodStatus(pod)
+		r.Images = process(pod)
 
 	} else {
 
 		// Build a Map to make use as a Set (unique list). Values are empty structs so they don't waste space
 		imageSet := make(map[string]ReportImage)
 		for _, image := range r.Images {
-			// There's always a tag, the repoDigest may be missing
+			// TODO: Use the image:tag@digest to test for uniqueness
 			imageSet[image.Tag] = image
 		}
+
 		// If the image isn't in the set already, append it to the list
-		for _, image := range getUniqueImagesFromPodStatus(pod) {
+		for _, image := range process(pod) {
 			if _, ok := imageSet[image.Tag]; !ok {
 				r.Images = append(r.Images, image)
 			}
@@ -79,27 +70,162 @@ func (r *ReportItem) AddImages(pod v1.Pod) {
 	}
 }
 
-func getUniqueImagesFromPodStatus(pod v1.Pod) []ReportImage {
-	imageMap := make(map[string]ReportImage)
-	for _, container := range pod.Status.ContainerStatuses {
-		repoDigest := getImageDigest(container.ImageID)
-		imageMap[container.Image] = ReportImage{
-			Tag:        container.Image,
-			RepoDigest: repoDigest,
-		}
-	}
-	imageSlice := make([]ReportImage, 0, len(imageMap))
-	for _, v := range imageMap {
-		imageSlice = append(imageSlice, v)
-	}
-	return imageSlice
+const regexTag = `:[\w][\w.-]{0,127}$`
+
+type Image struct {
+	digest string
+	tag    string
+	image  string
+	key    string
 }
 
-func getImageDigest(imageID string) string {
-	var imageDigest = ""
-	// If the image ID contains "sha", it corresponds to the repo digest. If not, it's not a digest
-	if strings.Contains(imageID, "@") {
-		imageDigest = strings.Split(imageID, "@")[1]
+type Spec struct {
+	image string
+}
+
+type Status struct {
+	image   string
+	imageID string
+}
+
+type data struct {
+	spec   Spec
+	status Status
+}
+
+func fill(pod v1.Pod) map[string]data {
+	cmap := make(map[string]data)
+
+	// grab init images
+	for _, c := range pod.Spec.InitContainers {
+		cmap[c.Name] = data{
+			spec: Spec{
+				image: c.Image,
+			},
+		}
 	}
-	return imageDigest
+
+	for _, c := range pod.Status.InitContainerStatuses {
+		mm, exists := cmap[c.Name]
+		spec := Spec{}
+
+		if exists {
+			spec = mm.spec
+		}
+
+		cmap[c.Name] = data{
+			spec: spec,
+			status: Status{
+				image:   c.Image,
+				imageID: c.ImageID,
+			},
+		}
+	}
+
+	// grab regular images
+	for _, c := range pod.Spec.Containers {
+		cmap[c.Name] = data{
+			spec: Spec{
+				image: c.Image,
+			},
+		}
+	}
+
+	for _, c := range pod.Status.ContainerStatuses {
+		mm, exists := cmap[c.Name]
+		spec := Spec{}
+
+		if exists {
+			spec = mm.spec
+		}
+
+		cmap[c.Name] = data{
+			spec: spec,
+			status: Status{
+				image:   c.Image,
+				imageID: c.ImageID,
+			},
+		}
+	}
+	return cmap
+}
+
+func parseout(s string, c *Image) error {
+
+	if c.digest != "" && c.tag != "" && c.image != "" {
+		log.Info("all fields have been parsed")
+		return nil
+	}
+
+	reg, err := regexp.Compile(regexTag)
+	if err != nil {
+		return err
+	}
+
+	image := s
+	digest := ""
+	if strings.Contains(s, "@") {
+		split := strings.Split(s, "@")
+		image = split[0]
+		digest = split[1]
+	}
+
+	tag := ""
+	m := reg.FindAllString(image, -1)
+	if len(m) > 0 {
+		i := strings.LastIndex(image, ":")
+		image = image[0:i]
+		tag = strings.TrimPrefix(m[0], ":")
+	}
+
+	if c.digest == "" {
+		c.digest = digest
+	}
+	if c.tag == "" {
+		c.tag = tag
+	}
+	if c.image == "" {
+		c.image = image
+	}
+	return nil
+}
+
+func extract(d data) (Image, error) {
+
+	c := Image{
+		image:  "",
+		tag:    "",
+		digest: "",
+		key:    "",
+	}
+
+	parseout(d.spec.image, &c)
+	parseout(d.status.image, &c)
+	parseout(d.status.imageID, &c)
+
+	c.key = fmt.Sprintf("%s:%s@%s", c.image, c.tag, c.digest)
+	return c, nil
+}
+
+func process(pod v1.Pod) []ReportImage {
+	cmap := fill(pod)
+
+	unique := make(map[string]Image)
+	for _, n := range cmap {
+		c, err := extract(n)
+		if err != nil {
+			log.Errorf("issue processing %s", n)
+			continue
+		}
+		unique[c.key] = c
+	}
+
+	ri := make([]ReportImage, 0)
+	for _, u := range unique {
+		ri = append(ri, ReportImage{
+			Tag:        fmt.Sprintf("%s:%s", u.image, u.tag),
+			RepoDigest: u.digest,
+		})
+	}
+	return ri
 }

--- a/kai/inventory/reportitem.go
+++ b/kai/inventory/reportitem.go
@@ -58,9 +58,12 @@ func (r *ReportItem) String() string {
 
 // Adds an ReportImage to the ReportItem struct (if it doesn't exist there already)
 func (r *ReportItem) AddImages(pod v1.Pod) {
+
 	if len(r.Images) == 0 {
 		r.Images = getUniqueImagesFromPodStatus(pod)
+
 	} else {
+
 		// Build a Map to make use as a Set (unique list). Values are empty structs so they don't waste space
 		imageSet := make(map[string]ReportImage)
 		for _, image := range r.Images {
@@ -95,8 +98,8 @@ func getUniqueImagesFromPodStatus(pod v1.Pod) []ReportImage {
 func getImageDigest(imageID string) string {
 	var imageDigest = ""
 	// If the image ID contains "sha", it corresponds to the repo digest. If not, it's not a digest
-	if strings.Contains(imageID, "sha") {
-		imageDigest = "sha" + strings.Split(imageID, "sha")[1]
+	if strings.Contains(imageID, "@") {
+		imageDigest = strings.Split(imageID, "@")[1]
 	}
 	return imageDigest
 }

--- a/kai/inventory/reportitem.go
+++ b/kai/inventory/reportitem.go
@@ -110,17 +110,12 @@ func parseout(s string, c *image) error {
 		return nil
 	}
 
-	regdigest, err := regexp.Compile(regexDigest)
-	if err != nil {
-		return err
-	}
-
 	image := s
 	digest := ""
-	d := regdigest.FindAllString(image, -1)
-	if len(d) > 0 {
-		digest = d[0]
-		image = strings.TrimRight(image, fmt.Sprintf("@%s", digest))
+	if strings.Contains(s, "@") {
+		split := strings.Split(s, "@")
+		image = split[0]
+		digest = split[1]
 	}
 
 	reg, err := regexp.Compile(regexTag)

--- a/kai/inventory/reportitem_test.go
+++ b/kai/inventory/reportitem_test.go
@@ -8,7 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func equivalent(left, right ReportItem, t *testing.T) error {
+func equivalent(left, right ReportItem) error {
 	if left.Namespace != right.Namespace {
 		return fmt.Errorf("Namespaces do not match %s != %s", left.Namespace, right.Namespace)
 	}
@@ -94,7 +94,7 @@ func TestSameTagDifferentDigestSamePod(t *testing.T) {
 			},
 		},
 	}
-	err := equivalent(actual, expected, t)
+	err := equivalent(actual, expected)
 	if err != nil {
 		t.Error(err)
 	}
@@ -172,7 +172,7 @@ func TestSameTagDifferentDigestDistinctPods(t *testing.T) {
 			},
 		},
 	}
-	err := equivalent(actual, expected, t)
+	err := equivalent(actual, expected)
 	if err != nil {
 		t.Error(err)
 	}
@@ -223,7 +223,7 @@ func TestAddImageWithDigestNoTag(t *testing.T) {
 			},
 		},
 	}
-	err := equivalent(actual, expected, t)
+	err := equivalent(actual, expected)
 	if err != nil {
 		t.Error(err)
 	}
@@ -274,7 +274,7 @@ func TestAddImageWithDigestWithTag(t *testing.T) {
 			},
 		},
 	}
-	err := equivalent(actual, expected, t)
+	err := equivalent(actual, expected)
 	if err != nil {
 		t.Error(err)
 	}
@@ -326,7 +326,7 @@ func TestAddImageNoDigestNoTag(t *testing.T) {
 			},
 		},
 	}
-	err := equivalent(actual, expected, t)
+	err := equivalent(actual, expected)
 	if err != nil {
 		t.Error(err)
 	}
@@ -376,7 +376,7 @@ func TestAddImageNoDigestWithTag(t *testing.T) {
 			},
 		},
 	}
-	err := equivalent(actual, expected, t)
+	err := equivalent(actual, expected)
 	if err != nil {
 		t.Error(err)
 	}
@@ -424,7 +424,7 @@ func TestInitContainer(t *testing.T) {
 			},
 		},
 	}
-	err := equivalent(actual, expected, t)
+	err := equivalent(actual, expected)
 	if err != nil {
 		t.Error(err)
 	}
@@ -532,7 +532,7 @@ func TestNewReportItem(t *testing.T) {
 			},
 		},
 	}
-	err := equivalent(actual, expected, t)
+	err := equivalent(actual, expected)
 	if err != nil {
 		t.Error(err)
 	}

--- a/kai/inventory/reportitem_test.go
+++ b/kai/inventory/reportitem_test.go
@@ -566,6 +566,7 @@ func TestNewReportItem(t *testing.T) {
 //
 //	Test out NewReportItem which takes a list of pods. Include pods with init
 //	containers and regular containers. Include a pod that is in a Pending state
+//	that should be ignored.
 //
 func TestNewReportItemNotRunningTrue(t *testing.T) {
 	namespace := "default"
@@ -670,6 +671,7 @@ func TestNewReportItemNotRunningTrue(t *testing.T) {
 //
 //	Test out NewReportItem which takes a list of pods. Include pods with init
 //	containers and regular containers. Include a pod that is in a Pending state
+//	that should still be captured.
 //
 func TestNewReportItemNotRunningFalse(t *testing.T) {
 	namespace := "default"

--- a/kai/inventory/reportitem_test.go
+++ b/kai/inventory/reportitem_test.go
@@ -8,6 +8,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+func logout(actual, expected ReportItem, t *testing.T) {
+	t.Log("")
+	t.Log("Actual")
+	for _, image := range actual.Images {
+		t.Logf("  %#v", image)
+	}
+	t.Log("")
+	t.Log("Expected")
+	for _, image := range expected.Images {
+		t.Logf("  %#v", image)
+	}
+	t.Log("")
+}
+
 func equivalent(left, right ReportItem) error {
 	if left.Namespace != right.Namespace {
 		return fmt.Errorf("Namespaces do not match %s != %s", left.Namespace, right.Namespace)
@@ -18,16 +32,16 @@ func equivalent(left, right ReportItem) error {
 	}
 
 	tmap := make(map[string]struct{})
-	for _, image := range left.Images {
+	for _, image := range right.Images {
 		key := fmt.Sprintf("%s@%s", image.Tag, image.RepoDigest)
 		tmap[key] = struct{}{}
 	}
 
-	for _, image := range right.Images {
+	for _, image := range left.Images {
 		key := fmt.Sprintf("%s@%s", image.Tag, image.RepoDigest)
 		_, exists := tmap[key]
 		if !exists {
-			return fmt.Errorf("Mismatch in ReportItem Images array %s does not exist", key)
+			return fmt.Errorf("Actual key %s not found in expected results", key)
 		}
 	}
 	return nil
@@ -77,10 +91,6 @@ func TestSameTagDifferentDigestSamePod(t *testing.T) {
 	}
 	actual.extractUniqueImages(mockPod)
 
-	for _, image := range actual.Images {
-		t.Log(image)
-	}
-
 	expected := ReportItem{
 		Namespace: namespace,
 		Images: []ReportImage{
@@ -96,6 +106,7 @@ func TestSameTagDifferentDigestSamePod(t *testing.T) {
 	}
 	err := equivalent(actual, expected)
 	if err != nil {
+		logout(actual, expected, t)
 		t.Error(err)
 	}
 }
@@ -155,10 +166,6 @@ func TestSameTagDifferentDigestDistinctPods(t *testing.T) {
 	}
 	actual := NewReportItem(mockPods, namespace)
 
-	for _, image := range actual.Images {
-		t.Log(image)
-	}
-
 	expected := ReportItem{
 		Namespace: namespace,
 		Images: []ReportImage{
@@ -174,6 +181,7 @@ func TestSameTagDifferentDigestDistinctPods(t *testing.T) {
 	}
 	err := equivalent(actual, expected)
 	if err != nil {
+		logout(actual, expected, t)
 		t.Error(err)
 	}
 }
@@ -225,6 +233,7 @@ func TestAddImageWithDigestNoTag(t *testing.T) {
 	}
 	err := equivalent(actual, expected)
 	if err != nil {
+		logout(actual, expected, t)
 		t.Error(err)
 	}
 }
@@ -276,6 +285,7 @@ func TestAddImageWithDigestWithTag(t *testing.T) {
 	}
 	err := equivalent(actual, expected)
 	if err != nil {
+		logout(actual, expected, t)
 		t.Error(err)
 	}
 }
@@ -328,6 +338,7 @@ func TestAddImageNoDigestNoTag(t *testing.T) {
 	}
 	err := equivalent(actual, expected)
 	if err != nil {
+		logout(actual, expected, t)
 		t.Error(err)
 	}
 }
@@ -378,6 +389,7 @@ func TestAddImageNoDigestWithTag(t *testing.T) {
 	}
 	err := equivalent(actual, expected)
 	if err != nil {
+		logout(actual, expected, t)
 		t.Error(err)
 	}
 }
@@ -426,6 +438,7 @@ func TestInitContainer(t *testing.T) {
 	}
 	err := equivalent(actual, expected)
 	if err != nil {
+		logout(actual, expected, t)
 		t.Error(err)
 	}
 }
@@ -534,6 +547,7 @@ func TestNewReportItem(t *testing.T) {
 	}
 	err := equivalent(actual, expected)
 	if err != nil {
+		logout(actual, expected, t)
 		t.Error(err)
 	}
 }

--- a/kai/inventory/reportitem_test.go
+++ b/kai/inventory/reportitem_test.go
@@ -33,6 +33,11 @@ func equivalent(left, right ReportItem, t *testing.T) error {
 	return nil
 }
 
+//
+//	Test out two containers with the same tag but different digests to ensure
+//	the uniqueness of images is parsed correctly when looking at a list of
+//	containers in a single pod
+//
 func TestSameTagDifferentDigestSamePod(t *testing.T) {
 	namespace := "default"
 	mockPod := v1.Pod{
@@ -95,6 +100,11 @@ func TestSameTagDifferentDigestSamePod(t *testing.T) {
 	}
 }
 
+//
+//	Test out two pods running containers with the same tag but different digests
+//	to ensure the uniqueness of images is parsed correctly when looking at
+//	individual pods in the same namespace
+//
 func TestSameTagDifferentDigestDistinctPods(t *testing.T) {
 	namespace := "default"
 	mockPods := []v1.Pod{
@@ -168,7 +178,11 @@ func TestSameTagDifferentDigestDistinctPods(t *testing.T) {
 	}
 }
 
-// kubectl run alpiney --image=alpine@sha256:4ed1812024ed78962a34727137627e8854a3b414d19e2c35a1dc727a47e16fba
+//
+//	Test out a pod running with an image added by digest only.
+//
+//	kubectl run alpiney --image=alpine@sha256:4ed1812024ed78962a34727137627e8854a3b414d19e2c35a1dc727a47e16fba
+//
 func TestAddImageWithDigestNoTag(t *testing.T) {
 	namespace := "default"
 	mockPod := v1.Pod{
@@ -215,7 +229,11 @@ func TestAddImageWithDigestNoTag(t *testing.T) {
 	}
 }
 
-// kubectl run alpiney --image=alpine:3.13.6@sha256:4ed1812024ed78962a34727137627e8854a3b414d19e2c35a1dc727a47e16fba
+//
+//	Test out a pod running with an image added by tag and digest.
+//
+//	kubectl run alpiney --image=alpine:3.13.6@sha256:4ed1812024ed78962a34727137627e8854a3b414d19e2c35a1dc727a47e16fba
+//
 func TestAddImageWithDigestWithTag(t *testing.T) {
 	namespace := "default"
 	mockPod := v1.Pod{
@@ -262,7 +280,13 @@ func TestAddImageWithDigestWithTag(t *testing.T) {
 	}
 }
 
-// kubectl run alpiney --image=alpine
+//
+//	Test out a pod running without a tag or digest (inferred 'latest')
+//
+//	kubectl run alpiney --image=alpine
+//
+//	TODO: Find where in the runtime this is actually inferred as latest
+//
 func TestAddImageNoDigestNoTag(t *testing.T) {
 	namespace := "default"
 	mockPod := v1.Pod{
@@ -308,7 +332,11 @@ func TestAddImageNoDigestNoTag(t *testing.T) {
 	}
 }
 
-// kubectl run alpiney --image=alpine:3
+//
+//	Test out a pod running with an image and tag but no digest.
+//
+//	kubectl run alpiney --image=alpine:3
+//
 func TestAddImageNoDigestWithTag(t *testing.T) {
 	namespace := "default"
 	mockPod := v1.Pod{
@@ -354,7 +382,9 @@ func TestAddImageNoDigestWithTag(t *testing.T) {
 	}
 }
 
-// kubectl run alpiney --image=alpine:3
+//
+//	Test out a pod running with an init container
+//
 func TestInitContainer(t *testing.T) {
 	namespace := "default"
 	mockPod := v1.Pod{
@@ -400,11 +430,14 @@ func TestInitContainer(t *testing.T) {
 	}
 }
 
-// kubectl run alpiney --image=alpine:3
+//
+//	Test out NewReportItem which takes a list of pods. Include pods with init
+//	containers and regular containers.
+//
 func TestNewReportItem(t *testing.T) {
 	namespace := "default"
 	mockPods := []v1.Pod{
-		{
+		{ // pod-1
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 			},
@@ -426,7 +459,7 @@ func TestNewReportItem(t *testing.T) {
 				},
 			},
 		},
-		{
+		{ // pod-2
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 			},
@@ -448,7 +481,7 @@ func TestNewReportItem(t *testing.T) {
 				},
 			},
 		},
-		{
+		{ // pod-3
 			ObjectMeta: metav1.ObjectMeta{
 				Namespace: namespace,
 			},


### PR DESCRIPTION
Attempt to parse the unique image details using a few more fields in the pod object along with some regexes.

Also added an `ignore-not-running` option so the end user can configure whether they want to capture image details from pods that are not running yet.