### PR TITLE
Handle the null tag edge case

### DIFF
--- a/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
@@ -30,6 +30,9 @@ kubernetes:
 namespaces:
   include: []
   exclude: []
+missingtagpolicy:
+  policy: digest
+  tag: UNKNOWN
 runmode: 0
 mode: adhoc
 ignorenotrunning: true

--- a/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
@@ -30,6 +30,9 @@ kubernetes:
 namespaces:
   include: []
   exclude: []
+missingtagpolicy:
+  policy: ""
+  tag: ""
 runmode: 0
 mode: ""
 ignorenotrunning: false

--- a/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
@@ -30,6 +30,9 @@ kubernetes:
 namespaces:
   include: []
   exclude: []
+missingtagpolicy:
+  policy: digest
+  tag: UNKNOWN
 runmode: 0
 mode: adhoc
 ignorenotrunning: true

--- a/kai.yaml
+++ b/kai.yaml
@@ -71,7 +71,7 @@ missing-tag-policy:
   #        recommended.
   policy: digest
 
-  # Only applicable in policy is 'insert'. Defaults to UNKNOWN
+  # Dummy tag to use. Only applicable if policy is 'insert'. Defaults to UNKNOWN
   tag: UNKNOWN
 
 

--- a/kai.yaml
+++ b/kai.yaml
@@ -58,6 +58,23 @@ kubernetes:
 # Can be one of adhoc, periodic (defaults to adhoc)
 mode: adhoc
 
+# Handle cases where a tag is missing. For example - images designated by digest
+missing-tag-policy:
+  # One of the following options [digest, insert, drop]
+  #
+  # [digest] will use the images digest as a dummy tag
+  #
+  # [insert] will insert a default tag in as a dummy tag. The dummy tag is
+  #          customizable under missing-tag-policy.tag
+  #
+  # [drop] will drop images that do not have tags associated with them. Not
+  #        recommended.
+  policy: digest
+
+  # Only applicable in policy is 'insert'. Defaults to UNKNOWN
+  tag: UNKNOWN
+
+
 # Ignore images out of pods that are not in a Running state
 ignore-not-running: true
 

--- a/kai.yaml
+++ b/kai.yaml
@@ -60,9 +60,9 @@ mode: adhoc
 
 # Handle cases where a tag is missing. For example - images designated by digest
 missing-tag-policy:
-  # One of the following options [digest, insert, drop]
+  # One of the following options [digest, insert, drop]. Default is 'digest'
   #
-  # [digest] will use the images digest as a dummy tag
+  # [digest] will use the image's digest as a dummy tag.
   #
   # [insert] will insert a default tag in as a dummy tag. The dummy tag is
   #          customizable under missing-tag-policy.tag

--- a/kai/lib.go
+++ b/kai/lib.go
@@ -298,7 +298,7 @@ func fetchPodsInNamespace(clientset *kubernetes.Clientset, cfg *config.Applicati
 	}
 
 	log.Debugf("There are %d pods in namespace \"%s\"", len(pods), ns)
-	ch.reportItem <- inventory.NewReportItem(pods, ns, cfg.IgnoreNotRunning)
+	ch.reportItem <- inventory.NewReportItem(pods, ns, cfg.IgnoreNotRunning, cfg.MissingTagPolicy.Policy, cfg.MissingTagPolicy.Tag)
 }
 
 func SetLogger(logger logger.Logger) {


### PR DESCRIPTION
There is still one case where a tag cannot be parsed out of a pod spec. When an image is added by digest only

for example

```sh
kubectl run python --image=python@sha256:f0a210a37565286ecaaac0529a6749917e8ea58d3dfc72c84acfbfbe1a64a20a --command -- sleep inf
```

This causes issue in Anchore Enterprise because it requires a tag. To remedy this in kai there are a couple options

1. Use the digest as the tag
2. Insert a dummy tag (specified by the end user)
3. Drop the image from the report