### PR TITLE
Update Go Linters and Fix New Lint Errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -19,6 +19,7 @@ linters:
     - dogsled
     - dupl
     - errcheck
+    - exportloopref
     - funlen
     - gocognit
     - goconst
@@ -26,7 +27,6 @@ linters:
     - gocyclo
     - gofmt
     - goimports
-    - golint
     - goprintffuncname
     - gosec
     - gosimple
@@ -36,8 +36,8 @@ linters:
     - nakedret
     - nolintlint
     - prealloc
+    - revive
     - rowserrcheck
-    - scopelint
     - staticcheck
     - structcheck
     - stylecheck

--- a/kai/inventory/reportitem.go
+++ b/kai/inventory/reportitem.go
@@ -108,8 +108,8 @@ type image struct {
 }
 
 // Compile the regexes used for parsing once so they can be reused without having to recompile
-var digestRegex *regexp.Regexp = regexp.MustCompile(`@(sha[[:digit:]]{3}:[[:alnum:]]{32,})`)
-var tagRegex *regexp.Regexp = regexp.MustCompile(`:[\w][\w.-]{0,127}$`)
+var digestRegex = regexp.MustCompile(`@(sha[[:digit:]]{3}:[[:alnum:]]{32,})`)
+var tagRegex = regexp.MustCompile(`:[\w][\w.-]{0,127}$`)
 
 // extractImageDetails extracts the repo, tag, and digest of an image out of the fields
 // grabbed from the pod.

--- a/kai/lib.go
+++ b/kai/lib.go
@@ -1,5 +1,6 @@
 /*
-Retrieve Kubernetes In-Use Image data from the Kubernetes API. Runs adhoc and periodically, using the k8s go SDK
+Package kai retrieves Kubernetes In-Use Image data from the Kubernetes API. Runs adhoc and periodically, using the
+k8s go SDK
 */
 package kai
 
@@ -178,7 +179,7 @@ func excludeSet(check map[string]struct{}) excludeCheck {
 }
 
 // Regex to determine whether a string is a valid namespace (valid dns name)
-var validNamespaceRegex *regexp.Regexp = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
+var validNamespaceRegex = regexp.MustCompile(`^[a-z0-9]([-a-z0-9]*[a-z0-9])?$`)
 
 // buildExclusionChecklist will create a list of checks based on the configured
 // exclusion strings. The checks could be regexes or direct string matches.


### PR DESCRIPTION
While running the Lint checks for KAI, I noticed that a couple of the
linters that golangci-lint was using were deprecated and had been
replaced by other, supported linters.

```
golint --> revive
scopelint --> exportloopref
```

This patch also fixes new linter issues found by these updated linters.

Signed-off-by: Dustin Schoenbrun <dustin.schoenbrun@anchore.com>