### PR TITLE
fix: avoid very large outputs to stdout and improve logging clarity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ coverage.txt
 # Kubeconfigs contain sensitive information and are specific to someone's environment
 # Ignore it in case anyone puts it in the dir
 kubeconfig
+
+# Location for checking out the chart for using skaffold
+anchore-charts

--- a/Dockerfile.skaffold
+++ b/Dockerfile.skaffold
@@ -1,0 +1,21 @@
+FROM gcr.io/distroless/static:nonroot
+
+COPY snapshot/kai /usr/bin
+
+USER nonroot:nobody
+
+ARG BUILD_DATE
+ARG BUILD_VERSION
+ARG VCS_REF
+ARG VCS_URL
+
+LABEL org.opencontainers.image.created=$BUILD_DATE
+LABEL org.opencontainers.image.title="kai"
+LABEL org.opencontainers.image.description="KAI (Kubernetes Automated Inventory) can poll Kubernetes Cluster API(s) to tell Anchore which Images are currently in-use"
+LABEL org.opencontainers.image.source=$VCS_URL
+LABEL org.opencontainers.image.revision=$VCS_REF
+LABEL org.opencontainers.image.vendor="Anchore, Inc."
+LABEL org.opencontainers.image.version=$BUILD_VERSION
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+ENTRYPOINT ["kai"]

--- a/Makefile
+++ b/Makefile
@@ -208,3 +208,8 @@ clean-snapshot:
 .PHONY: clean-dist
 clean-dist:
 	rm -rf $(DISTDIR) $(TEMPDIR)/goreleaser.yaml
+
+.PHONY: bootstrap-skaffold
+bootstrap-skaffold:
+	$(call title, Cloning chart for local skaffold dev)
+	git clone git@github.com:anchore/anchore-charts.git

--- a/README.md
+++ b/README.md
@@ -462,6 +462,17 @@ KAI comes with shell completion for specifying namespaces, it can be enabled as 
 kai completion <zsh|bash|fish>
 ```
 
+### Using Skaffold
+You can use skaffold for dev. The 'bootstrap-skaffold' make target will clone the chart into the current directory to wire
+it up for skaffold to use. To trigger redeployments you'll need to run `make linux-binary` and skaffold will rebuild the image
+and update the helm release.
+
+```sh
+make bootstrap-skaffold
+make linux-binary
+skaffold dev
+```
+
 ## Releasing
 To create a release of kai, a tag needs to be created that points to a commit in `main`
 that we want to release. This tag shall be a semver prefixed with a `v`, e.g. `v0.2.7`.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -56,6 +56,7 @@ type Application struct {
 	IgnoreNotRunning                bool        `mapstructure:"ignore-not-running"`
 	PollingIntervalSeconds          int         `mapstructure:"polling-interval-seconds"`
 	AnchoreDetails                  AnchoreInfo `mapstructure:"anchore"`
+	QuietInventoryReports           bool        `mapstructure:"quiet-inventory-reports"`
 }
 
 // MissingTagConf details the policy for handling missing tags when reporting images

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,22 @@
+apiVersion: skaffold/v4beta2
+kind: Config
+metadata:
+  name: kai
+build:
+  artifacts:
+  - image: local/kai
+    docker:
+      dockerfile: Dockerfile.skaffold
+deploy:
+  helm:
+    releases:
+    - name: kai
+      chartPath: anchore-charts/stable/kai
+      setValueTemplates:
+        image.repository: "{{.IMAGE_REPO_local_kai}}"
+        image.tag: "{{.IMAGE_TAG_local_kai}}"
+      setValues:
+        kai.log.level: debug
+        kai.log.structured: false
+        kai.quiet: false
+        kai.quietReports: false


### PR DESCRIPTION
Adds 'quiet-inventory-reports' configuration option to suppress writing the full inventory to stdout when set. This is useful for agent-like usage where log aggregators and k8s log rotation will not easily handle 1MB+ log lines when a very large inventory (1000s of images) is detected.

For development ease, also adds ability to use skaffold for development (Dockerfile, make targets, and skaffold config).