### PR TITLE
feat: improve logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ coverage.txt
 # Kubeconfigs contain sensitive information and are specific to someone's environment
 # Ignore it in case anyone puts it in the dir
 kubeconfig
+
+# Location for checking out the chart for using skaffold
+anchore-charts

--- a/Dockerfile.skaffold
+++ b/Dockerfile.skaffold
@@ -1,0 +1,21 @@
+FROM gcr.io/distroless/static:nonroot
+
+COPY snapshot/kai /usr/bin
+
+USER nonroot:nobody
+
+ARG BUILD_DATE
+ARG BUILD_VERSION
+ARG VCS_REF
+ARG VCS_URL
+
+LABEL org.opencontainers.image.created=$BUILD_DATE
+LABEL org.opencontainers.image.title="kai"
+LABEL org.opencontainers.image.description="KAI (Kubernetes Automated Inventory) can poll Kubernetes Cluster API(s) to tell Anchore which Images are currently in-use"
+LABEL org.opencontainers.image.source=$VCS_URL
+LABEL org.opencontainers.image.revision=$VCS_REF
+LABEL org.opencontainers.image.vendor="Anchore, Inc."
+LABEL org.opencontainers.image.version=$BUILD_VERSION
+LABEL org.opencontainers.image.licenses="Apache-2.0"
+
+ENTRYPOINT ["kai"]

--- a/Makefile
+++ b/Makefile
@@ -208,3 +208,8 @@ clean-snapshot:
 .PHONY: clean-dist
 clean-dist:
 	rm -rf $(DISTDIR) $(TEMPDIR)/goreleaser.yaml
+
+.PHONY: bootstrap-skaffold
+bootstrap-skaffold:
+	$(call title, Cloning chart for local skaffold dev)
+	git clone https://github.com/anchore/anchore-charts.git

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ By default, KAI will look for a Kubeconfig in the home directory to use to authe
 
 ### CLI
 ```shell script
-$ kai
+$ kai --verbose-inventory-reports
 {
   "timestamp": "2021-11-17T18:47:36Z",
   "results": [
@@ -88,7 +88,7 @@ $ kai
 
 In order to run kai as a container, it needs a kubeconfig
 ```sh
-~ docker run -it --rm -v ~/.kube/config:/.kube/config anchore/kai:v0.3.0
+~ docker run -it --rm -v ~/.kube/config:/.kube/config anchore/kai:v0.5.0 --verbose-inventory-reports
 {
   "timestamp": "2021-11-17T18:47:36Z",
   "results": [
@@ -231,6 +231,9 @@ kubeconfig:
     client-cert:
     private-key:
     token:
+
+# enable/disable printing inventory reports to stdout
+verbose-inventory-reports: false
 ```
 
 ### Namespace selection
@@ -378,6 +381,13 @@ anchore:
     insecure: true
     timeout-seconds: 10
 ```
+
+## Behavior change (v0.5.0)
+
+In versions of KAI < v0.5.0 the default behavior was to output the inventory report
+to stdout every time it was generated. KAI v0.5.0 changes this so it will not print
+to stdout unless `verbose-inventory-reports: true` is set in the config file or
+KAI is called with the `--verbose-inventory-reports` flag.
 
 ## Configuration Changes (v0.2.2 -> v0.3.0)
 

--- a/README.md
+++ b/README.md
@@ -462,6 +462,17 @@ KAI comes with shell completion for specifying namespaces, it can be enabled as 
 kai completion <zsh|bash|fish>
 ```
 
+### Using Skaffold
+You can use skaffold for dev. The 'bootstrap-skaffold' make target will clone the chart into the current directory to wire
+it up for skaffold to use. To trigger redeployments you'll need to run `make linux-binary` and skaffold will rebuild the image
+and update the helm release.
+
+```sh
+make bootstrap-skaffold
+make linux-binary
+skaffold dev
+```
+
 ## Releasing
 To create a release of kai, a tag needs to be created that points to a commit in `main`
 that we want to release. This tag shall be a semver prefixed with a `v`, e.g. `v0.2.7`.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,4 +96,11 @@ func init() {
 		fmt.Printf("unable to bind flag '%s': %+v", opt, err)
 		os.Exit(1)
 	}
+
+	opt = "verbose-inventory-reports"
+	rootCmd.Flags().BoolP(opt, "i", false, "If true, will print the full inventory report to stdout")
+	if err := viper.BindPFlag(opt, rootCmd.Flags().Lookup(opt)); err != nil {
+		fmt.Printf("unable to bind flag '%s': %+v", opt, err)
+		os.Exit(1)
+	}
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,6 +21,7 @@ var rootCmd = &cobra.Command{
     Kubernetes Cluster API(s) to tell Anchore which Images are currently in-use`,
 	Args: cobra.MaximumNArgs(0),
 	Run: func(cmd *cobra.Command, args []string) {
+		log.Info("KAI is starting up...")
 		if appConfig.Dev.ProfileCPU {
 			f, err := os.Create("cpu.profile")
 			if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,6 +12,8 @@ package config
 
 import (
 	"fmt"
+	"path"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 
@@ -23,9 +25,6 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
-
-	"path"
-	"strings"
 )
 
 const redacted = "******"
@@ -201,7 +200,7 @@ func (cfg *Application) Build() error {
 			case v >= 2:
 				cfg.Log.LevelOpt = logrus.DebugLevel
 			default:
-				cfg.Log.LevelOpt = logrus.ErrorLevel
+				cfg.Log.LevelOpt = logrus.InfoLevel
 			}
 		}
 	}
@@ -320,7 +319,6 @@ func (cfg Application) String() string {
 
 	// yaml is pretty human friendly (at least when compared to json)
 	appCfgStr, err := yaml.Marshal(&cfg)
-
 	if err != nil {
 		return err.Error()
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,6 +55,7 @@ type Application struct {
 	IgnoreNotRunning                bool        `mapstructure:"ignore-not-running"`
 	PollingIntervalSeconds          int         `mapstructure:"polling-interval-seconds"`
 	AnchoreDetails                  AnchoreInfo `mapstructure:"anchore"`
+	VerboseInventoryReports         bool        `mapstructure:"verbose-inventory-reports"`
 }
 
 // MissingTagConf details the policy for handling missing tags when reporting images

--- a/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestDefaultConfigString.golden
@@ -47,3 +47,4 @@ anchoredetails:
   http:
     insecure: false
     timeoutseconds: 10
+verboseinventoryreports: false

--- a/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestEmptyConfigString.golden
@@ -47,3 +47,4 @@ anchoredetails:
   http:
     insecure: false
     timeoutseconds: 0
+verboseinventoryreports: false

--- a/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
+++ b/internal/config/test-fixtures/snapshot/TestSensitiveConfigString.golden
@@ -47,3 +47,4 @@ anchoredetails:
   http:
     insecure: false
     timeoutseconds: 10
+verboseinventoryreports: false

--- a/internal/tracker/time.go
+++ b/internal/tracker/time.go
@@ -1,0 +1,27 @@
+package tracker
+
+import (
+	"time"
+
+	"github.com/anchore/kai/internal/log"
+)
+
+// TrackFunctionTime is a function that tracks the time it takes to execute a function
+// and logs the time it took to execute the function
+//
+// It takes a time.Time object and a string as parameters
+// The time.Time object is the time the function started executing
+// The string is the name of the function that is being tracked (or any arbitrary message useful for logging)
+//
+// It is intended to be run at the beginning of a function and defer the function call
+// for example:
+//
+//	func someFunction() {
+//		start := time.Now()
+//		defer TrackFunctionTime(start, "someFunction")
+//		// do stuff
+//	}
+func TrackFunctionTime(start time.Time, msg string) {
+	elapsed := time.Since(start)
+	log.Log.Debugf("%s took %s", msg, elapsed)
+}

--- a/kai/lib.go
+++ b/kai/lib.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/anchore/kai/internal/config"
 	"github.com/anchore/kai/internal/log"
+	"github.com/anchore/kai/internal/tracker"
 	"github.com/anchore/kai/kai/client"
 	"github.com/anchore/kai/kai/inventory"
 	"github.com/anchore/kai/kai/logger"
@@ -224,6 +225,7 @@ func excludeNamespace(checks []excludeCheck, namespace string) bool {
 // OR if there are no namespaces listed in the configuration then it will
 // return every namespace in the cluster.
 func fetchNamespaces(kubeconfig *rest.Config, cfg *config.Application) ([]string, error) {
+	defer tracker.TrackFunctionTime(time.Now(), "Fetching namespaces")
 	namespaces := make([]string, 0)
 
 	exclusionChecklist := buildExclusionChecklist(cfg.NamespaceSelectors.Exclude)
@@ -275,6 +277,7 @@ func fetchNamespaces(kubeconfig *rest.Config, cfg *config.Application) ([]string
 
 // Atomic Function that gets all the Namespace Images for a given searchNamespace and reports them to the unbuffered results channel
 func fetchPodsInNamespace(clientset *kubernetes.Clientset, cfg *config.Application, ns string, ch channels) {
+	defer tracker.TrackFunctionTime(time.Now(), "Fetching pods in namespace: "+ns)
 	pods := make([]v1.Pod, 0)
 	cont := ""
 	for {

--- a/kai/lib.go
+++ b/kai/lib.go
@@ -1,8 +1,7 @@
 /*
 Package kai retrieves Kubernetes In-Use Image data from the Kubernetes API. Runs adhoc and periodically, using the
 k8s go SDK
-*/
-package kai
+*/package kai
 
 import (
 	"context"
@@ -41,8 +40,10 @@ func HandleReport(report inventory.Report, cfg *config.Application) error {
 		log.Debug("Anchore details not specified, not reporting inventory")
 	}
 
-	if err := presenter.GetPresenter(cfg.PresenterOpt, report).Present(os.Stdout); err != nil {
-		return fmt.Errorf("unable to show inventory: %w", err)
+	if cfg.VerboseInventoryReports {
+		if err := presenter.GetPresenter(cfg.PresenterOpt, report).Present(os.Stdout); err != nil {
+			return fmt.Errorf("unable to show inventory: %w", err)
+		}
 	}
 	return nil
 }

--- a/kai/reporter/reporter.go
+++ b/kai/reporter/reporter.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/anchore/kai/internal/config"
 	"github.com/anchore/kai/internal/log"
+	"github.com/anchore/kai/internal/tracker"
 	"github.com/anchore/kai/kai/inventory"
 )
 
@@ -21,6 +22,7 @@ const ReportAPIPath = "v1/enterprise/inventories"
 //
 //nolint:gosec
 func Post(report inventory.Report, anchoreDetails config.AnchoreInfo) error {
+	defer tracker.TrackFunctionTime(time.Now(), "Reporting results to Anchore for cluster: "+report.ClusterName+"")
 	log.Debug("Reporting results to Anchore")
 	tr := &http.Transport{
 		TLSClientConfig: &tls.Config{InsecureSkipVerify: anchoreDetails.HTTP.Insecure},

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -1,0 +1,22 @@
+apiVersion: skaffold/v4beta2
+kind: Config
+metadata:
+  name: kai
+build:
+  artifacts:
+  - image: local/kai
+    docker:
+      dockerfile: Dockerfile.skaffold
+deploy:
+  helm:
+    releases:
+    - name: kai
+      chartPath: anchore-charts/stable/kai
+      setValueTemplates:
+        image.repository: "{{.IMAGE_REPO_local_kai}}"
+        image.tag: "{{.IMAGE_TAG_local_kai}}"
+      setValues:
+        kai.log.level: debug
+        kai.log.structured: false
+        kai.quiet: false
+        kai.quietReports: false

--- a/skaffold.yaml
+++ b/skaffold.yaml
@@ -19,4 +19,5 @@ deploy:
         kai.log.level: debug
         kai.log.structured: false
         kai.quiet: false
-        kai.quietReports: false
+        kai.verboseInventoryReports: false
+        kai.pollingIntervalSeconds: 60


### PR DESCRIPTION
- chore: adds support for using skaffold for development
- feat: change default logging level to Info
- feat: no longer output inventory reports to stdout by default
- feat: log function execution times
- chore: add some useful info logs

Example of the log output with these changes:
```
[kai] [2023-03-21 23:33:08]  INFO KAI is starting up...
[kai] [2023-03-21 23:33:08]  INFO Starting image inventory collection
[kai] [2023-03-21 23:33:08] DEBUG using in-cluster kube config
[kai] [2023-03-21 23:33:08] DEBUG Fetching namespaces took 68.73675ms
[kai] [2023-03-21 23:33:08]  INFO There are 0 pods in namespace "kube-node-lease"
[kai] [2023-03-21 23:33:08] DEBUG Fetching pods in namespace: kube-node-lease took 41.1165ms
[kai] [2023-03-21 23:33:08]  INFO There are 0 pods in namespace "kube-public"
[kai] [2023-03-21 23:33:08] DEBUG Fetching pods in namespace: kube-public took 45.363083ms
[kai] [2023-03-21 23:33:08]  INFO There are 2 pods in namespace "default"
[kai] [2023-03-21 23:33:08]  INFO There are 2 pods in namespace "kubernetes-dashboard"
[kai] [2023-03-21 23:33:08] DEBUG Fetching pods in namespace: kubernetes-dashboard took 47.022833ms
[kai] [2023-03-21 23:33:08] DEBUG Fetching pods in namespace: default took 87.507542ms
[kai] [2023-03-21 23:33:08]  INFO There are 7 pods in namespace "kube-system"
[kai] [2023-03-21 23:33:08] DEBUG Fetching pods in namespace: kube-system took 102.045834ms
[kai] [2023-03-21 23:33:08]  INFO Got Inventory Report with 10 images running across 5 namespaces
[kai] [2023-03-21 23:33:08]  INFO Anchore details not specified, not reporting inventory
[kai] [2023-03-21 23:33:08]  INFO Waiting 60 seconds for next poll...
```